### PR TITLE
Clone1b: Add RDF format examples and external LDF service integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/3
-Your prepared branch: issue-3-7324c929c079
-Your prepared working directory: /tmp/gh-issue-solver-1767109696091
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR implements issue #3 with the following features:

- **Added example loaders for all supported RDF input formats:**
  - Turtle (existing, refactored)
  - N-Triples (new)
  - N-Quads (new)  
  - TriG (new)

- **Added "Показать в окне" button** that opens the visualization in a new window via the external LDF RDF Grapher service (`https://www.ldf.fi/service/rdf-grapher`) with URL parameters:
  - `rdf=` - encoded RDF data
  - `from=` - input format (ttl, nt, nq, trig)
  - `to=png` - output format

## Changes

- Extended example links in description section: `Turtle | N-Triples | N-Quads | TriG`
- Added format-specific example loader functions with appropriate RDF data for each format
- Added `openInNewWindow()` function with format mapping to LDF service parameters
- Added third button "Показать в окне" next to existing export buttons

## Test plan

- [x] Test loading Turtle example - loads data and selects correct format
- [x] Test loading N-Triples example - loads data and selects correct format
- [x] Test loading N-Quads example - loads data and selects correct format
- [x] Test loading TriG example - loads data and selects correct format
- [x] Test visualization works with all formats
- [x] Test "Показать в окне" button generates correct URL for LDF service

Fixes bpmbpm/rdf-grapher#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)