### PR TITLE
Add separate buttons for GitHub Pages and ldf.fi visualization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/5
-Your prepared branch: issue-5-fbff24b8a6f4
-Your prepared working directory: /tmp/gh-issue-solver-1767111104454
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR implements the feature requested in issue #5:

- **Renamed** the existing "Показать в окне" button to "Показать в окне ldf.fi" - this button uses the external https://www.ldf.fi/service to render the RDF graph
- **Added** a new "Показать в окне github" button - this button opens the visualization in a new window using only local Viz.js rendering, without any external service dependency

## Implementation Details

The new "Показать в окне github" button:
- Uses the SVG graph already generated locally by Viz.js
- Creates a standalone HTML page with proper styling
- Opens the page in a new browser window
- Works entirely client-side on GitHub Pages without external service dependencies

## Test Plan

- [x] Load example RDF data (Turtle, N-Triples, N-Quads, or TriG)
- [x] Click "Визуализировать" to generate the graph
- [x] Verify "Показать в окне github" opens a new window with the SVG graph
- [x] Verify "Показать в окне ldf.fi" still works with the external service

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)