### PR TITLE
Add prefixed names, Namespaces block and zoom controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/9
-Your prepared branch: issue-9-f0a5e263aef0
-Your prepared working directory: /tmp/gh-issue-solver-1767122034643
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary
This PR implements the features requested in issue #9:

- **Prefixed predicate and node names**: Labels now display full prefixed names (e.g., `foaf:name`, `ex:john`, `rdf:type`) instead of just local names (e.g., `name`, `john`, `type`)
- **Namespaces block on diagram**: Added a "Namespaces" box showing all used prefixes and their full URIs, similar to the LDF rdf-grapher service at https://www.ldf.fi/service/rdf-grapher
- **Diagram scaling/zoom**: Added zoom controls to scale the diagram window with:
  - Zoom in (+) / Zoom out (-) buttons
  - Reset to 100% button
  - "Fit" button to fit graph in visible area
  - Scrollable container for viewing large graphs

## Test plan
- [x] Load Turtle example and verify prefixed names appear on nodes (ex:john, foaf:Person) and edges (foaf:name, rdf:type)
- [x] Verify Namespaces block appears on the diagram showing used prefixes
- [x] Test zoom in/out buttons change the scale percentage
- [x] Test "Reset" button returns to 100%
- [x] Test "Fit" button scales graph to fit in viewport
- [x] Test horizontal scrolling works for large graphs
- [x] Test N-Triples format (which has no prefixes) shows local names correctly

## Screenshots
The implementation follows the pattern from the reference service (https://www.ldf.fi/service/rdf-grapher):
- Nodes display prefixed URIs (e.g., `ex:john`, `foaf:Person`)
- Edges display prefixed predicates (e.g., `foaf:name`, `rdf:type`)
- Namespaces block shows the prefix definitions

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)