### PR TITLE
Display @Prefix block in separate panel below graph with clickable URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/11
-Your prepared branch: issue-11-40df364d85ae
-Your prepared working directory: /tmp/gh-issue-solver-1767155418303
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR implements the feature requested in issue #11 - display the `@Prefix` block not in the graph image, but in a separate panel below it, with clickable URLs.

### Changes made:
- **Removed Namespaces node from graph**: The Namespaces block is no longer embedded as a node inside the SVG graph
- **Added Prefixes panel**: A new HTML container is added below the graph zoom-container to display prefixes
- **Styled panel**: CSS styles match the existing UI design (gray background, monospace font, clickable links)
- **Clickable URLs**: All namespace URLs (`<http://...>`) are rendered as clickable links that open in a new tab
- **Dynamic display**: The panel only appears when there are prefixes to display, and hides during loading/errors

### Implementation details:
- Added `displayPrefixes()` function that takes parsed prefixes and renders them as HTML with clickable links
- Panel shows prefixes in Turtle-like syntax: `@prefix foaf: <http://xmlns.com/foaf/0.1/> .`
- Prefixes are sorted alphabetically for consistent display

## Test plan
- [x] Load Turtle example with `@prefix` declarations
- [x] Visualize the RDF data
- [x] Verify Namespaces block is NOT shown inside the graph
- [x] Verify Prefixes panel appears below the graph
- [x] Verify all URLs in prefixes are clickable links
- [x] Test with N-Triples format (no prefixes) - panel should be hidden

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)