### PR TITLE
Add node properties panel and update legend with full prefixed names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/15
-Your prepared branch: issue-15-362067891809
-Your prepared working directory: /tmp/gh-issue-solver-1767160718503
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR implements the features requested in issue #15:

1. **Updated Node Styles legend to display full prefixed names:**
   - "Люди (foaf:Person)" instead of "Люди (Person)"
   - "Организации (foaf:Organization)" instead of "Организации (Organization)"
   - "Документы (foaf:Document)" instead of "Документы (Document)"

2. **Added clickable node functionality:**
   - Clicking on any graph node (subject or object) opens a properties panel on the left side
   - The panel shows all properties (predicate + value) where the clicked node is the subject
   - For example, clicking on `ex:john` displays:
     - `foaf:name "John Doe"`
     - `foaf:age "30"`
     - `foaf:knows ex:jane`
     - and other properties of ex:john
   - Panel includes node type badge showing RDF type (e.g., `foaf:Person`)
   - Panel can be closed via × button
   - Selected node is highlighted in the graph

## Test Plan

- [x] Load Turtle example and visualize
- [x] Verify legend shows "Люди (foaf:Person)", "Организации (foaf:Organization)", etc.
- [x] Click on ex:john node and verify properties panel appears
- [x] Verify panel shows all properties: rdf:type, foaf:name, foaf:age, foaf:knows
- [x] Verify close button works
- [x] Test with N-Triples format (without prefixes)

## Screenshots

When clicking on `ex:john` node, the properties panel appears showing all its properties:
- rdf:type → foaf:Person
- foaf:name → "John Doe"
- foaf:age → "30"
- foaf:knows → ex:jane
- foaf:knows → ex:bob

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)