### PR TITLE
Implement issue #23: Add FilterBase for basic mode with different defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/23
-Your prepared branch: issue-23-e994ad827511
-Your prepared working directory: /tmp/gh-issue-solver-1767170442303
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary
- Added `FilterBase` constant with empty `hiddenPredicates` for basic mode (no types hidden by default)
- Added `getFilterConfig()` function to select filter configuration based on current visualization mode
- Enabled filter panel display for **both modes** (base and notation) with different default settings:
  - **Notation mode**: `rdf:type` and `rdfs:subClassOf` are hidden by default
  - **Basic mode**: All predicates are visible by default (nothing hidden)

## Changes
- `ver2/index.html`: Added FilterBase configuration and mode-aware filter initialization

## Test plan
- [x] Verify filter panel appears in notation mode with `rdf:type` hidden by default
- [x] Verify filter panel appears in basic mode with all predicates visible by default
- [x] Verify switching between modes resets filters to mode-specific defaults
- [x] Verify filter checkboxes work correctly in both modes

Fixes bpmbpm/rdf-grapher#23

🤖 Generated with [Claude Code](https://claude.com/claude-code)