### PR TITLE
Fix aggregation mode: show legend and make max params configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/29
-Your prepared branch: issue-29-15d50ac01ed8
-Your prepared working directory: /tmp/gh-issue-solver-1767179420778
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR addresses the issues from #29:

- **Show Style Legend in aggregation mode**: The legend panel was hidden in aggregation mode. Now it displays correctly, showing the appropriate AggregationNodeStyles (all ellipses with different colors/borders based on RDF type).

- **Make max parameters configurable**: Added `MaxAggregationParams` global constant to configure the maximum number of rows (parameters) displayed in aggregated nodes. Previously this was hardcoded as a local `MAX_PARAMS = 5` constant inside a function.

- **SPARQL result node highlighting**: Tested and verified that clicking on SPARQL result rows correctly highlights the corresponding node in the graph schema. This functionality was already working as expected.

## Changes

1. Added new global constant `MaxAggregationParams = 5` in the configuration section (line 1094)
2. Updated legend visibility condition to include aggregation mode: `currentMode === 'notation' || currentMode === 'aggregation'`
3. Replaced local `MAX_PARAMS` usage with the global `MaxAggregationParams` constant

## Test Plan

- [x] Load Turtle example data
- [x] Select "Режим агрегации" (Aggregation mode)
- [x] Verify "Легенда стилей" (Style Legend) panel is visible
- [x] Verify legend shows aggregation-specific styles (all ellipses)
- [x] Enable SPARQL mode and execute query
- [x] Click on SPARQL result rows and verify corresponding graph nodes are highlighted
- [x] Verify nodes display correct number of parameters (up to MaxAggregationParams)

Fixes bpmbpm/rdf-grapher#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)