### PR TITLE
Add Drawio export and fix color conflicts with highlight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/32
-Your prepared branch: issue-32-6e9337d93a75
-Your prepared working directory: /tmp/gh-issue-solver-1767183477876
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR addresses issue #32 with the following changes:

- **Fix color conflicts**: Changed node and edge colors to avoid conflict with the highlight color (#FF5722) used for SPARQL result selection
  - PersonStyle: Changed from red to purple (#9C27B0) with light purple fill (#F3E5F5)
  - MemberStyle edge: Changed from orange (#FF9800) to brown (#795548)
  - AggregationNodeStyles PersonStyle: Updated with matching purple colors

- **Add Drawio export**: Added new "Drawio (несжатый)" output format that generates uncompressed XML compatible with https://app.diagrams.net/
  - New dropdown option in output format selector
  - New "Скачать Drawio" button in export buttons
  - Implemented `rdfToDrawio()` and `downloadDrawio()` functions
  - Automatic file download when Drawio format is selected

## Test plan

- [x] Verify PersonStyle nodes display with purple color instead of red
- [x] Verify MemberStyle edges display with brown color instead of orange
- [x] Verify highlighting of SPARQL results is visually distinct from node/edge colors
- [x] Test Drawio export button downloads valid .drawio file
- [x] Verify downloaded .drawio file can be opened in https://app.diagrams.net/
- [x] Test Drawio output format option auto-downloads the file on visualization

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)