### PR TITLE
Fix Drawio export: support aggregation mode, remove auto-download, add node offset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/34
-Your prepared branch: issue-34-3fe9374eaacc
-Your prepared working directory: /tmp/gh-issue-solver-1767185253164
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary
- **Removed automatic Drawio download** when clicking Visualize button - now download happens only via the "Скачать Drawio" button
- **Added aggregation mode support for Drawio export** - in aggregation mode, literals are now properly aggregated into subject nodes (matching the SVG visualization)
- **Added small random offset (±15px) to node coordinates** to avoid placing nodes in a straight vertical or horizontal line

## Changes Made
1. Removed `downloadDrawio()` call from the `visualize()` function when output format is drawio
2. Updated `downloadDrawio()` to filter quads based on current active filters
3. Created new `rdfToDrawioAggregation()` function that aggregates literals into subject nodes
4. Modified `rdfToDrawio()` to delegate to aggregation version when in aggregation mode
5. Added offset calculation to node positioning in both `rdfToDrawio()` and `rdfToDrawioAggregation()`

## Test plan
- [x] Verify Visualize button with Drawio format doesn't auto-download
- [x] Verify "Скачать Drawio" button downloads the file
- [x] Verify aggregation mode properly aggregates literals in Drawio export
- [x] Verify filters are respected in Drawio export
- [x] Verify node coordinates have slight offset to avoid straight lines

Fixes bpmbpm/rdf-grapher#34

🤖 Generated with [Claude Code](https://claude.com/claude-code)