### PR TITLE
fix(ver6d): Add vad:processSubtype and vad:hasTrig to VAD_ALLOWED_PREDICATES

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,3 @@ Proceed.
 
 
 Run timestamp: 2026-01-07T19:16:00.691Z
-
----
-
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/88
-Your prepared branch: issue-88-19766db71b36
-Your prepared working directory: /tmp/gh-issue-solver-1767994539368
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.
-
-
-Run timestamp: 2026-01-09T21:35:44.883Z


### PR DESCRIPTION
## Summary

This PR fixes the VAD TriG mode in ver6d which was not displaying the diagram or export buttons.

**Root cause**: The VAD validation was failing because `vad:processSubtype` and `vad:hasTrig` predicates (introduced in PR #85 for process subtypes) were not included in the `VAD_ALLOWED_PREDICATES` array.

**Changes:**
- Added `vad:processSubtype` and `http://example.org/vad#processSubtype` to `VAD_ALLOWED_PREDICATES`
- Added `vad:hasTrig` and `http://example.org/vad#hasTrig` to `VAD_ALLOWED_PREDICATES`
- Updated `formatVADErrors` help message to list the new allowed predicates

## Test Plan

- [x] Load "Trig VADv2" example in ver6d
- [x] Select "Режим VAD TriG" visualization mode
- [x] Click "Визуализировать"
- [x] Verify diagram is displayed with process flow (p1 Процесс 1 → Процесс 2 → ... → Процесс 8)
- [x] Verify export buttons appear: "Скачать SVG", "Скачать PNG", "Показать в окне github", "Показать в окне ldf.fi", "Показать в окне GraphvizOnline"
- [x] Verify tree panel shows TriG hierarchy
- [x] Verify properties panel shows object properties

Fixes bpmbpm/rdf-grapher#88

🤖 Generated with [Claude Code](https://claude.com/claude-code)