### PR TITLE
fix(ver6d): Apply ProcessStyleDetailed (blue) for vad:Detailed processes and fix GitHub URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/40
+Your prepared branch: issue-40-4938b5c5bfab
+Your prepared working directory: /tmp/gh-issue-solver-1767201421712
+Your forked repository: konard/bpmbpm-rdf-grapher
+Original repository (upstream): bpmbpm/rdf-grapher
+
+Proceed.
+
+---
+
+Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/82
+Your prepared branch: issue-82-2f8b420cfeb6
+Your prepared working directory: /tmp/gh-issue-solver-1767813354965
+Your forked repository: konard/bpmbpm-rdf-grapher
+Original repository (upstream): bpmbpm/rdf-grapher
+
+Proceed.
+
+
+Run timestamp: 2026-01-07T19:16:00.691Z


### PR DESCRIPTION
## Summary
- Fix VAD TriG diagram to apply blue style (ProcessStyleDetailed) for processes with `vad:processSubtype vad:Detailed`, while keeping green style (ProcessStyleBasic) for processes with `vad:Basic` subtype
- Fix "Показать в окне github" button to use correct base URL `/rdf-grapher/ver6d/` instead of `/rdf-grapher/ver4p/`
- Visualization mode is preserved when navigating via the GitHub button

## Changes
1. **rdfToDotVAD function**: Now checks `nodeSubtypesCache` for each process to determine if it has `vad:Detailed` subtype, and applies the appropriate style:
   - `ProcessStyleDetailed`: blue color (`#1565C0` border, `#90CAF9` fill) for Detailed processes
   - `ProcessStyleBasic`: green color (`#2E7D32` border, `#A5D6A7` fill) for Basic processes (default)

2. **openInNewWindowGitHub function**: Changed base URL from `ver4p` to `ver6d`

## Test plan
- [x] Load "Trig VADv2" example
- [x] Verify `vad:p1` (which has `vad:processSubtype vad:Detailed`) is displayed with blue fill
- [x] Verify other processes (with `vad:processSubtype vad:Basic`) are displayed with green fill
- [x] Click "Показать в окне github" and verify it opens ver6d with correct mode

Fixes bpmbpm/rdf-grapher#90

🤖 Generated with [Claude Code](https://claude.com/claude-code)