### PR TITLE
feat: Add vad:ptree graph for process metadata in TriG VADv2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,3 @@ Proceed.
 
 
 Run timestamp: 2026-01-07T19:16:00.691Z
-
----
-
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/99
-Your prepared branch: issue-99-d2578bf24138
-Your prepared working directory: /tmp/gh-issue-solver-1768907637793
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.
-
-
-Run timestamp: 2026-01-20T11:14:04.502Z


### PR DESCRIPTION
## Summary

This PR implements the vad:ptree (Process Tree) feature for the TriG VADv2 example as requested in issue #99.

### Changes Made

- **Added `PTREE_PREDICATES` constant** - defines predicates that should be stored in vad:ptree for vad:Process entities: `rdfs:label`, `dcterms:description`, `vad:hasTrig`
- **Added helper functions**:
  - `isPtreePredicate()` - checks if a predicate belongs to ptree
  - `isSubjectVadProcess()` - checks if subject is a vad:Process type
  - `findDuplicateTriple()` - detects duplicate triples across all graphs (supports both full URI and prefixed name formats)
  - `determineTargetGraph()` - routes new triples to vad:ptree when applicable
  - `getProcessMetadataFromPtree()` - retrieves process metadata from vad:ptree

- **Added vad:ptree named graph** to TriG VADv2 example with:
  - Graph metadata: `rdfs:label "Дерево Процессов (TriG)"` and `vad:hasParent vad:root`
  - Process metadata from vad:t1 (p1, Process2-8)
  - Process metadata from vad:t1.1 (Process21-28)

- **Updated Smart Design** to:
  - Check for duplicate triples before creating
  - Automatically route triples to vad:ptree for vad:Process subjects with PTREE_PREDICATES

- **Updated visualization** to:
  - Exclude vad:ptree from root TriG selection (so it doesn't become the main display graph)
  - Use fallback to getProcessMetadataFromPtree when labels not found in current TriG

### Test Plan

- [x] Load "Trig VADv2" example and verify vad:ptree graph is included
- [x] Verify process labels are correctly displayed from vad:ptree
- [x] Verify TriG tree shows vad:t1 as root (not vad:ptree)
- [x] Test duplicate check: try adding existing rdfs:label to vad:p1 → shows error "Triple already exists in graph vad:ptree"
- [x] Test ptree routing: new rdfs:label for vad:Process should go to vad:ptree
- [x] Verify visualization renders correctly with VAD diagram

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)