### PR TITLE
fix(ver7s): Fix process visualization when rdf:type is in vad:ptree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/40
+Your prepared branch: issue-40-4938b5c5bfab
+Your prepared working directory: /tmp/gh-issue-solver-1767201421712
+Your forked repository: konard/bpmbpm-rdf-grapher
+Original repository (upstream): bpmbpm/rdf-grapher
+
+Proceed.
+
+---
+
+Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/82
+Your prepared branch: issue-82-2f8b420cfeb6
+Your prepared working directory: /tmp/gh-issue-solver-1767813354965
+Your forked repository: konard/bpmbpm-rdf-grapher
+Original repository (upstream): bpmbpm/rdf-grapher
+
+Proceed.
+
+
+Run timestamp: 2026-01-07T19:16:00.691Z


### PR DESCRIPTION
## Summary

Fixes process schema visualization not displaying when rdf:type statements are stored in vad:ptree graph.

### Problem

After PR #100 and #102, the `rdf:type vad:Process` statements were moved from individual TriG graphs (vad:t1, vad:t1.1) to a separate `vad:ptree` (Process Tree) graph. This caused:

- Process schemas (TriG) not being displayed when clicking "Визуализировать" button
- Properties panel showing "Процессы (vad:Process): 0 шт." instead of the correct count
- Empty VAD diagram with only the title visible

### Root Cause

1. `buildNodeTypesCache()` only processed quads from the selected TriG, missing the type information now stored in vad:ptree
2. `parseTriGHierarchy()` only looked for `rdf:type vad:Process` within each graph's own quads

### Solution

- Modified `buildNodeTypesCache()` to also include types from `vad:ptree` when available
- Updated `parseTriGHierarchy()` to:
  - First collect all process URIs from all graphs (including ptree)  
  - Then detect processes in each TriG by checking for process-related predicates (`vad:hasExecutor`, `vad:hasNext`, `vad:processSubtype`)

## Test Plan

- [x] Load "Trig VADv2" example
- [x] Select "Режим VAD TriG" mode
- [x] Click "Визуализировать" button
- [x] Verify processes are displayed in the diagram (8 processes for vad:t1, 8 for vad:t1.1)
- [x] Verify properties panel shows correct process count
- [x] Verify SPARQL mode works correctly
- [x] Click on child TriG (t1.1) and verify visualization works

Fixes bpmbpm/rdf-grapher#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)