### PR TITLE
Fix issue #193: ver8tree_2Det_1e

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,16 +18,3 @@ Proceed.
 
 
 Run timestamp: 2026-01-07T19:16:00.691Z
-
----
-
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/193
-Your prepared branch: issue-193-c4bd3d388620
-Your prepared working directory: /tmp/gh-issue-solver-1769542972067
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.
-
-
-Run timestamp: 2026-01-27T19:42:57.974Z


### PR DESCRIPTION
## Summary

This PR addresses the requirements from issue #193 (ver8tree_2Det_1e).

### Changes Made

1. **Removed hasParentTrig backward compatibility code**
   - Removed from `FilterVAD.hiddenPredicates`
   - Removed from `VAD_ALLOWED_PREDICATES`
   - Removed from `OBJECT_PROPERTIES` (VADProcessDia, ProcessTree, ExecutorTree sections)
   - Removed from `HasParentStyle.predicates`
   - Removed parsing code that analyzed `hasParentTrig` predicate in two locations

2. **Added "Показать в окне ldf.fi (TriG)" button**
   - New button in the export buttons section
   - Passes RDF data to ldf.fi service with explicit TriG format (`from=trig`)
   - Fixes the "Error in RDF parsing. Error on line 11 - { ... } is not allowed in Turtle" error

### Files Modified

- `ver8tree/index.html` - Main application file with all changes

## Test plan

- [ ] Load the Trig_VADv5 example and verify it displays correctly
- [ ] Click "Показать в окне ldf.fi (TriG)" button and verify it opens ldf.fi with TriG format
- [ ] Verify that the old "Показать в окне ldf.fi" button still works (uses Turtle format)
- [ ] Verify that data using hasParentObj (not hasParentTrig) still works correctly

Fixes bpmbpm/rdf-grapher#193

---
*Generated with [Claude Code](https://claude.com/claude-code)*