### PR TITLE
fix: Migrate all files from currentQuads to currentStore.getQuads() (issue #326)

### DIFF
--- a/ver9c/2_triplestore/2_triplestore_ui.js
+++ b/ver9c/2_triplestore/2_triplestore_ui.js
@@ -30,10 +30,11 @@ function updateQuadstoreDisplay() {
     if (!rdfInput) return;
 
     // Получаем отфильтрованные квады
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
     const filterMode = currentTrigFilterMode || TRIG_FILTER_MODES.NO_TECH;
     const filteredQuads = typeof getFilteredQuads === 'function'
         ? getFilteredQuads(filterMode)
-        : currentQuads;
+        : (currentStore ? currentStore.getQuads(null, null, null, null) : []);
 
     if (!filteredQuads || filteredQuads.length === 0) {
         rdfInput.value = '';
@@ -75,9 +76,10 @@ function clearRdfInput() {
 function saveAsFile() {
     // issue #262: Получаем квады БЕЗ TechnoTree типов (режим noTech)
     // независимо от текущего фильтра отображения
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
     const filteredQuads = typeof getFilteredQuads === 'function'
         ? getFilteredQuads(TRIG_FILTER_MODES.NO_TECH)
-        : currentQuads;
+        : (currentStore ? currentStore.getQuads(null, null, null, null) : []);
 
     if (!filteredQuads || filteredQuads.length === 0) {
         alert('Нет данных для сохранения');

--- a/ver9c/3_sd/3_sd_create_new_individ/3_sd_create_new_individ_logic.js
+++ b/ver9c/3_sd/3_sd_create_new_individ/3_sd_create_new_individ_logic.js
@@ -101,9 +101,11 @@ function getConceptsForIndividManual(typeUri, graphUri) {
     const rdfTypeUri = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
     const rdfsLabelUri = 'http://www.w3.org/2000/01/rdf-schema#label';
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
         const conceptUris = new Set();
-        currentQuads.forEach(quad => {
+        quads.forEach(quad => {
             if (quad.predicate.value === rdfTypeUri &&
                 quad.object.value === typeUri &&
                 quad.graph && quad.graph.value === graphUri) {
@@ -115,7 +117,7 @@ function getConceptsForIndividManual(typeUri, graphUri) {
             let label = typeof getPrefixedName === 'function'
                 ? getPrefixedName(uri, currentPrefixes) : uri;
 
-            currentQuads.forEach(quad => {
+            quads.forEach(quad => {
                 if (quad.subject.value === uri &&
                     quad.predicate.value === rdfsLabelUri &&
                     quad.graph && quad.graph.value === graphUri) {
@@ -150,15 +152,17 @@ function getTrigsForIndivid() {
         const vadProcessDiaUri = 'http://example.org/vad#VADProcessDia';
         const rdfsLabelUri = 'http://www.w3.org/2000/01/rdf-schema#label';
 
-        if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-            currentQuads.forEach(quad => {
+        // issue #326: Используем currentStore.getQuads() вместо currentQuads
+        if (currentStore) {
+            const quads = currentStore.getQuads(null, null, null, null);
+            quads.forEach(quad => {
                 if (quad.predicate.value === rdfTypeUri &&
                     quad.object.value === vadProcessDiaUri) {
                     let label = typeof getPrefixedName === 'function'
                         ? getPrefixedName(quad.subject.value, currentPrefixes)
                         : quad.subject.value;
                     // Find label
-                    currentQuads.forEach(q2 => {
+                    quads.forEach(q2 => {
                         if (q2.subject.value === quad.subject.value &&
                             q2.predicate.value === rdfsLabelUri) {
                             label = q2.object.value;
@@ -190,8 +194,10 @@ function getTrigsForIndivid() {
 function checkIndividExistsInTrig(conceptUri, trigUri) {
     const isSubprocessTrigUri = 'http://example.org/vad#isSubprocessTrig';
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-        return currentQuads.some(quad =>
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+        return quads.some(quad =>
             quad.subject.value === conceptUri &&
             quad.predicate.value === isSubprocessTrigUri &&
             quad.object.value === trigUri &&
@@ -212,8 +218,10 @@ function getIndividsInTrig(trigUri) {
     const ptreeUri = 'http://example.org/vad#ptree';
     const individs = [];
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-        currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+        quads.forEach(quad => {
             if (quad.predicate.value === isSubprocessTrigUri &&
                 quad.object.value === trigUri &&
                 quad.graph && quad.graph.value === trigUri) {
@@ -222,7 +230,7 @@ function getIndividsInTrig(trigUri) {
                     : quad.subject.value;
 
                 // Find label from ptree
-                currentQuads.forEach(q2 => {
+                quads.forEach(q2 => {
                     if (q2.subject.value === quad.subject.value &&
                         q2.predicate.value === rdfsLabelUri &&
                         q2.graph && q2.graph.value === ptreeUri) {
@@ -277,8 +285,10 @@ function getProcessConceptsForHasNext() {
 function findExecutorGroupForProcessIndivid(processIndividUri, trigUri) {
     const hasExecutorUri = 'http://example.org/vad#hasExecutor';
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-        for (const quad of currentQuads) {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+        for (const quad of quads) {
             if (quad.subject.value === processIndividUri &&
                 quad.predicate.value === hasExecutorUri &&
                 quad.graph && quad.graph.value === trigUri) {
@@ -299,7 +309,8 @@ function findExecutorGroupForProcessIndivid(processIndividUri, trigUri) {
  */
 function openNewIndividModal() {
     // Проверяем, что данные загружены
-    if (typeof currentQuads === 'undefined' || currentQuads.length === 0) {
+    // issue #326: Используем currentStore вместо currentQuads
+    if (!currentStore || currentStore.size === 0) {
         alert('Данные quadstore пусты. Загрузите пример данных (Trig_VADv5 или Trig_VADv6) в разделе "Загрузить пример RDF данных".\n\nQuadstore is empty. Load example data (Trig_VADv5 or Trig_VADv6) in "Load example RDF data" section.');
         return;
     }

--- a/ver9c/3_sd/3_sd_create_new_trig/3_sd_create_new_trig_logic.js
+++ b/ver9c/3_sd/3_sd_create_new_trig/3_sd_create_new_trig_logic.js
@@ -112,8 +112,9 @@ let newTrigIntermediateSparqlQueries = [];
  * - Затем открывается окно
  */
 async function openNewTrigModal() {
-    // issue #291: Проверяем, что данные загружены и распарсены (как в New Concept и Del Concept)
-    if (typeof currentQuads === 'undefined' || currentQuads.length === 0) {
+    // issue #291, #326: Проверяем, что данные загружены и распарсены
+    // issue #326: Используем currentStore вместо currentQuads
+    if (!currentStore || currentStore.size === 0) {
         alert('Данные quadstore пусты. Загрузите пример данных (Trig_VADv5 или Trig_VADv6) в разделе "Загрузить пример RDF данных".\n\nQuadstore is empty. Load example data (Trig_VADv5 or Trig_VADv6) in "Load example RDF data" section.');
         return;
     }

--- a/ver9c/3_sd/3_sd_del_concept_individ/3_sd_del_concept_individ_logic.js
+++ b/ver9c/3_sd/3_sd_del_concept_individ/3_sd_del_concept_individ_logic.js
@@ -246,11 +246,13 @@ function getConceptsManual(typeUri, graphUri) {
     const rdfTypeUri = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
     const rdfsLabelUri = 'http://www.w3.org/2000/01/rdf-schema#label';
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
         const conceptUris = new Set();
 
         // Найти все концепты с указанным типом в указанном графе
-        currentQuads.forEach(quad => {
+        quads.forEach(quad => {
             if (quad.predicate.value === rdfTypeUri &&
                 quad.object.value === typeUri &&
                 quad.graph && quad.graph.value === graphUri) {
@@ -264,7 +266,7 @@ function getConceptsManual(typeUri, graphUri) {
                 : uri;
 
             // Ищем label В ТОМ ЖЕ ГРАФЕ, где находится концепт
-            currentQuads.forEach(quad => {
+            quads.forEach(quad => {
                 if (quad.subject.value === uri &&
                     quad.predicate.value === rdfsLabelUri &&
                     quad.graph && quad.graph.value === graphUri) {
@@ -346,15 +348,17 @@ function findProcessIndividualsManual(conceptUri) {
     // Issue #221 Fix #2: Отладочная информация (отключена по умолчанию)
     const DEBUG_INDIVID_SEARCH = false;
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
         if (DEBUG_INDIVID_SEARCH) {
             console.log(`[findProcessIndividualsManual] Поиск индивидов для концепта: ${conceptUri}`);
-            console.log(`[findProcessIndividualsManual] Всего квадов: ${currentQuads.length}`);
+            console.log(`[findProcessIndividualsManual] Всего квадов: ${quads.length}`);
         }
 
         // Issue #221 Fix #2: Находим все TriG типа VADProcessDia
         const vadProcessDiaTrigs = new Set();
-        currentQuads.forEach(quad => {
+        quads.forEach(quad => {
             if (quad.predicate.value === rdfTypeUri &&
                 quad.object.value === vadProcessDiaUri) {
                 vadProcessDiaTrigs.add(quad.subject.value);
@@ -370,7 +374,7 @@ function findProcessIndividualsManual(conceptUri) {
 
         // Issue #221 Fix #2: Ищем использования данного концепта как индивида (vad:isSubprocessTrig)
         // во ВСЕХ TriG типа VADProcessDia
-        currentQuads.forEach(quad => {
+        quads.forEach(quad => {
             // Проверяем предикат vad:isSubprocessTrig
             const predicateMatches = quad.predicate.value === isSubprocessTrigUri ||
                 quad.predicate.value.endsWith('#isSubprocessTrig');
@@ -423,14 +427,16 @@ function findConceptAsIndividualInTrigs(conceptUri) {
     // Issue #219 Fix #1: Отладочная информация (отключена по умолчанию)
     const DEBUG_INDIVID_DETECTION = false;
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
         if (DEBUG_INDIVID_DETECTION) {
             console.log(`[findConceptAsIndividualInTrigs] Поиск для концепта: ${conceptUri}`);
-            console.log(`[findConceptAsIndividualInTrigs] Всего квадов: ${currentQuads.length}`);
+            console.log(`[findConceptAsIndividualInTrigs] Всего квадов: ${quads.length}`);
         }
 
         // Ищем все случаи, где данный концепт используется как индивид (subject с isSubprocessTrig)
-        currentQuads.forEach(quad => {
+        quads.forEach(quad => {
             // Issue #219 Fix #1: Расширенная проверка - также поддерживаем сокращенные URI
             const subjectMatches = quad.subject.value === conceptUri ||
                 (typeof getPrefixedName === 'function' &&
@@ -463,7 +469,7 @@ function findConceptAsIndividualInTrigs(conceptUri) {
         }
     } else {
         if (DEBUG_INDIVID_DETECTION) {
-            console.log(`[findConceptAsIndividualInTrigs] currentQuads не определён или не массив`);
+            console.log(`[findConceptAsIndividualInTrigs] currentStore не определён`);
         }
     }
 
@@ -492,8 +498,10 @@ function checkProcessSchema(conceptUri) {
         const hasTrigUri = 'http://example.org/vad#hasTrig';
         const ptreeUri = 'http://example.org/vad#ptree';
 
-        if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-            currentQuads.forEach(quad => {
+        // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+            quads.forEach(quad => {
                 if (quad.subject.value === conceptUri &&
                     quad.predicate.value === hasTrigUri &&
                     quad.graph && quad.graph.value === ptreeUri) {
@@ -544,8 +552,10 @@ function checkChildrenElements(conceptUri, graphUri) {
     if (children.length === 0) {
         const hasParentObjUri = 'http://example.org/vad#hasParentObj';
 
-        if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-            currentQuads.forEach(quad => {
+        // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+            quads.forEach(quad => {
                 if (quad.predicate.value === hasParentObjUri &&
                     quad.object.value === conceptUri &&
                     quad.graph && quad.graph.value === graphUri) {
@@ -595,8 +605,10 @@ function checkExecutorUsage(executorUri) {
     if (usages.length === 0) {
         const includesUri = 'http://example.org/vad#includes';
 
-        if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-            currentQuads.forEach(quad => {
+        // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+            quads.forEach(quad => {
                 if (quad.predicate.value === includesUri &&
                     quad.object.value === executorUri &&
                     quad.graph) {
@@ -646,8 +658,10 @@ function getAllTrigs() {
         const rdfTypeUri = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
         const vadProcessDiaUri = 'http://example.org/vad#VADProcessDia';
 
-        if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-            currentQuads.forEach(quad => {
+        // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+            quads.forEach(quad => {
                 if (quad.predicate.value === rdfTypeUri &&
                     quad.object.value === vadProcessDiaUri) {
                     trigs.push({
@@ -681,8 +695,10 @@ function findConceptForTrig(trigUri) {
     const hasTrigUri = 'http://example.org/vad#hasTrig';
     const ptreeUri = 'http://example.org/vad#ptree';
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-        for (const quad of currentQuads) {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+        for (const quad of quads) {
             if (quad.predicate.value === hasTrigUri &&
                 quad.object.value === trigUri &&
                 quad.graph && quad.graph.value === ptreeUri) {
@@ -703,9 +719,10 @@ function findConceptForTrig(trigUri) {
  * Вызывается по клику на кнопку "Del Concept\Individ"
  */
 function openDelConceptModal() {
-    // Issue #223, #282: Проверяем, что данные загружены и распарсены
+    // Issue #223, #282, #326: Проверяем, что данные загружены и распарсены
     // issue #282: Удалено сообщение "нажмите кнопку Показать" - данные загружаются автоматически
-    if (typeof currentQuads === 'undefined' || currentQuads.length === 0) {
+    // issue #326: Используем currentStore вместо currentQuads
+    if (!currentStore || currentStore.size === 0) {
         alert('Данные quadstore пусты. Загрузите пример данных (Trig_VADv5 или Trig_VADv6) в разделе "Загрузить пример RDF данных".\n\nQuadstore is empty. Load example data (Trig_VADv5 or Trig_VADv6) in "Load example RDF data" section.');
         return;
     }
@@ -1094,8 +1111,10 @@ function findProcessIndividualsInTrig(trigUri) {
     const isSubprocessTrigUri = 'http://example.org/vad#isSubprocessTrig';
     const seen = new Set();
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-        currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+        quads.forEach(quad => {
             const predicateMatches = quad.predicate.value === isSubprocessTrigUri ||
                 quad.predicate.value.endsWith('#isSubprocessTrig');
 
@@ -1124,8 +1143,10 @@ function findExecutorIndividualsInTrig(trigUri) {
     const includesUri = 'http://example.org/vad#includes';
     const seen = new Set();
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-        currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+        quads.forEach(quad => {
             const predicateMatches = quad.predicate.value === includesUri ||
                 quad.predicate.value.endsWith('#includes');
 
@@ -1154,8 +1175,10 @@ function findExecutorUsageInTrig(executorUri, trigUri) {
     const usages = [];
     const includesUri = 'http://example.org/vad#includes';
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-        currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+        quads.forEach(quad => {
             const predicateMatches = quad.predicate.value === includesUri ||
                 quad.predicate.value.endsWith('#includes');
 
@@ -1637,8 +1660,10 @@ function findExecutorGroupForIndivid(individUri, trigUri) {
     // issue #309: Отладочная информация (отключена по умолчанию)
     const DEBUG_EG_SEARCH = false;
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-        for (const quad of currentQuads) {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+        for (const quad of quads) {
             if (quad.subject.value === individUri &&
                 quad.predicate.value === hasExecutorUri &&
                 quad.graph && quad.graph.value === trigUri) {
@@ -1669,8 +1694,10 @@ function findIncomingHasNext(individUri, trigUri) {
     // issue #309: Отладочная информация (отключена по умолчанию)
     const DEBUG_HN_SEARCH = false;
 
-    if (typeof currentQuads !== 'undefined' && Array.isArray(currentQuads)) {
-        currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    if (currentStore) {
+        const quads = currentStore.getQuads(null, null, null, null);
+        quads.forEach(quad => {
             if (quad.predicate.value === hasNextUri &&
                 quad.object.value === individUri &&
                 quad.graph && quad.graph.value === trigUri) {

--- a/ver9c/3_sd/3_sd_logic.js
+++ b/ver9c/3_sd/3_sd_logic.js
@@ -188,10 +188,9 @@ async function applyTripleToRdfInput(sparqlQuery, mode) {
     const isDrop = sparqlQuery.includes('DROP');
 
     try {
-        // issue #254: Инициализируем N3.Store если нужно
+        // issue #254, #326: Инициализируем N3.Store если нужно
         if (!currentStore) {
             currentStore = new N3.Store();
-            currentQuads.forEach(q => currentStore.addQuad(q));
         }
 
         // issue #254: Инициализируем Comunica engine если нужно
@@ -209,8 +208,7 @@ async function applyTripleToRdfInput(sparqlQuery, mode) {
             sources: [currentStore]
         });
 
-        // issue #254: Обновляем currentQuads из store после изменения
-        currentQuads = currentStore.getQuads(null, null, null, null);
+        // issue #326: currentQuads удалён - все операции через currentStore
 
         // issue #254: Сериализуем обновлённые данные обратно в TriG через N3.Writer
         const trigText = await serializeStoreToTriG(currentStore, currentPrefixes);
@@ -330,9 +328,10 @@ function replaceFullUrisWithPrefixes(trigText, prefixes) {
 }
 
 /**
- * issue #254: Обновляет quadstore (currentQuads, currentPrefixes, currentStore) из содержимого textarea RDF данных
+ * issue #254, #326: Обновляет quadstore (currentPrefixes, currentStore) из содержимого textarea RDF данных
  * Используется при ручном редактировании textarea или при нажатии кнопки "Показать"
  * Примечание: функция applyTripleToRdfInput теперь использует Comunica напрямую и не вызывает эту функцию
+ * issue #326: currentQuads удалён - все операции через currentStore (N3.Store)
  */
 function refreshQuadstoreFromRdfInput() {
     const rdfInput = document.getElementById('rdf-input');
@@ -365,9 +364,8 @@ function refreshQuadstoreFromRdfInput() {
 
         // Обновляем глобальные переменные
         if (quads.length > 0) {
-            currentQuads = quads;
             currentPrefixes = prefixes;
-            // issue #324: Обновляем currentStore (единственное хранилище)
+            // issue #324, #326: Обновляем currentStore (единственное хранилище)
             currentStore = new N3.Store();
             quads.forEach(q => currentStore.addQuad(q));
 

--- a/ver9c/3_sd/3_sd_ui.js
+++ b/ver9c/3_sd/3_sd_ui.js
@@ -74,7 +74,9 @@ function getAllSubjects() {
     const subjects = [];
     const seen = new Set();
 
-    currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    const quads = currentStore ? currentStore.getQuads(null, null, null, null) : [];
+    quads.forEach(quad => {
         const uri = quad.subject.value;
         if (!seen.has(uri)) {
             seen.add(uri);
@@ -94,7 +96,9 @@ function getAllPredicates() {
     const predicates = [];
     const seen = new Set();
 
-    currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    const quads = currentStore ? currentStore.getQuads(null, null, null, null) : [];
+    quads.forEach(quad => {
         const uri = quad.predicate.value;
         if (!seen.has(uri)) {
             seen.add(uri);
@@ -114,7 +118,9 @@ function getAllObjects() {
     const objects = [];
     const seen = new Set();
 
-    currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    const quads = currentStore ? currentStore.getQuads(null, null, null, null) : [];
+    quads.forEach(quad => {
         // Исключаем литералы согласно требованиям
         if (quad.object.termType !== 'Literal') {
             const uri = quad.object.value;
@@ -517,7 +523,9 @@ function getProcessSubjects() {
     const subjects = [];
     const seen = new Set();
 
-    currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    const quads = currentStore ? currentStore.getQuads(null, null, null, null) : [];
+    quads.forEach(quad => {
         const uri = quad.subject.value;
         if (!seen.has(uri) && isSubjectVadProcess(uri)) {
             seen.add(uri);
@@ -547,7 +555,9 @@ function getSubjectsByType(typeValue) {
         }
     }
 
-    currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    const quads = currentStore ? currentStore.getQuads(null, null, null, null) : [];
+    quads.forEach(quad => {
         const uri = quad.subject.value;
         if (seen.has(uri)) return;
 
@@ -642,7 +652,9 @@ function getPtreePredicates() {
     const seen = new Set();
 
     // Добавляем только предикаты, которые есть в PTREE_PREDICATES и присутствуют в данных
-    currentQuads.forEach(quad => {
+    // issue #326: Используем currentStore.getQuads() вместо currentQuads
+    const quads = currentStore ? currentStore.getQuads(null, null, null, null) : [];
+    quads.forEach(quad => {
         const uri = quad.predicate.value;
         const prefixedName = getPrefixedName(uri, currentPrefixes);
         if (!seen.has(uri) && (isPtreePredicate(uri) || isPtreePredicate(prefixedName))) {
@@ -1045,7 +1057,9 @@ function getProcessIndividualsInTriG(trigUri) {
         const seen = new Set();
         const normalizedTrigUri = normalizeUri(trigUri);
 
-        currentQuads.forEach(quad => {
+        // issue #326: Используем currentStore.getQuads() вместо currentQuads
+        const allQuads = currentStore ? currentStore.getQuads(null, null, null, null) : [];
+        allQuads.forEach(quad => {
             const predUri = quad.predicate.value;
             const isSubprocessTrig = predUri === 'http://example.org/vad#isSubprocessTrig' ||
                                      predUri.endsWith('#isSubprocessTrig');
@@ -1058,7 +1072,7 @@ function getProcessIndividualsInTriG(trigUri) {
                     seen.add(subjectUri);
                     // Пытаемся найти label из ptree
                     let label = getPrefixedName(subjectUri, currentPrefixes);
-                    currentQuads.forEach(q => {
+                    allQuads.forEach(q => {
                         if (q.subject.value === subjectUri &&
                             (q.predicate.value === 'http://www.w3.org/2000/01/rdf-schema#label' ||
                              q.predicate.value.endsWith('#label')) &&
@@ -1093,7 +1107,9 @@ function getExecutorGroupsInTriG(trigUri) {
         const seen = new Set();
         const normalizedTrigUri = normalizeUri(trigUri);
 
-        currentQuads.forEach(quad => {
+        // issue #326: Используем currentStore.getQuads() вместо currentQuads
+        const allQuads = currentStore ? currentStore.getQuads(null, null, null, null) : [];
+        allQuads.forEach(quad => {
             // Ищем субъекты с rdf:type vad:ExecutorGroup в данном графе
             const isTypeTriple = quad.predicate.value === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' ||
                                  quad.predicate.value.endsWith('#type');
@@ -1107,7 +1123,7 @@ function getExecutorGroupsInTriG(trigUri) {
                     seen.add(subjectUri);
                     // Ищем label
                     let label = getPrefixedName(subjectUri, currentPrefixes);
-                    currentQuads.forEach(q => {
+                    allQuads.forEach(q => {
                         if (q.subject.value === subjectUri &&
                             (q.predicate.value === 'http://www.w3.org/2000/01/rdf-schema#label' ||
                              q.predicate.value.endsWith('#label'))) {

--- a/ver9c/8_infoSPARQL/8_infoSPARQL_ui.js
+++ b/ver9c/8_infoSPARQL/8_infoSPARQL_ui.js
@@ -1,10 +1,10 @@
 // Ссылка на issue: https://github.com/bpmbpm/rdf-grapher/issues/232
 // 8_infoSPARQL_ui.js - UI модуль панели SPARQL запросов
 
+        // issue #326: Используем только currentStore (N3.Store), currentQuads удалён
         async function initSparqlEngine() {
             if (!currentStore) {
                 currentStore = new N3.Store();
-                currentQuads.forEach(quad => currentStore.addQuad(quad));
             }
 
             if (!comunicaEngine) {
@@ -28,7 +28,8 @@
                 return;
             }
 
-            if (currentQuads.length === 0) {
+            // issue #326: Проверяем currentStore вместо currentQuads
+            if (!currentStore || currentStore.size === 0) {
                 resultsContent.innerHTML = '<div class="sparql-error">Сначала визуализируйте RDF данные</div>';
                 resultsDiv.style.display = 'block';
                 return;


### PR DESCRIPTION
## Summary

This fix completes the migration started in PR #325 (issue #324) by updating all files that still referenced the removed `currentQuads` variable to use `currentStore.getQuads()` directly from the N3.Store.

### Root Cause

PR #325 (issue #324) removed the global `currentQuads` array to migrate to using only `currentStore` (N3.Store). However, many files in the codebase still referenced `currentQuads`, causing JavaScript "currentQuads is not defined" errors when:
- Loading files manually via the file upload
- Using Smart Design features (New Concept, New Individ, New TriG, Del Concept)
- Using SPARQL queries

### Solution (Updated per owner feedback)

Instead of restoring `currentQuads`, all affected files have been updated to use `currentStore.getQuads()` directly, completing the migration to N3.Store:

1. **Pattern used:** `currentStore.getQuads(null, null, null, null)` to get all quads
2. **Condition checks:** Changed `typeof currentQuads !== 'undefined'` to `if (currentStore)`
3. **Empty check:** Changed `currentQuads.length === 0` to `currentStore.size === 0`

### Files Changed

| File | Changes |
|------|---------|
| `ver9c/3_sd/3_sd_ui.js` | Updated getAllSubjects(), getAllPredicates(), getAllObjects(), getProcessSubjects(), getSubjectsByType(), getPtreePredicates(), getProcessIndividualsInTriG(), getExecutorGroupsInTriG() |
| `ver9c/3_sd/3_sd_logic.js` | Updated applyTripleToRdfInput(), refreshQuadstoreFromRdfInput() |
| `ver9c/2_triplestore/2_triplestore_ui.js` | Updated updateQuadstoreDisplay(), saveAsFile() |
| `ver9c/8_infoSPARQL/8_infoSPARQL_ui.js` | Updated initSparqlEngine(), executeSparqlQuery() |
| `ver9c/3_sd/3_sd_create_new_trig/3_sd_create_new_trig_logic.js` | Updated openNewTrigModal() |
| `ver9c/3_sd/3_sd_create_new_concept/3_sd_create_new_concept_logic.js` | Updated getPredicatesForNewConceptManual(), getObjectsByTypeManual(), checkIdExists(), openNewConceptModal() |
| `ver9c/3_sd/3_sd_create_new_individ/3_sd_create_new_individ_logic.js` | Updated getConceptsForIndividManual(), getTrigsForIndivid(), checkIndividExistsInTrig(), getIndividsInTrig(), findExecutorGroupForProcessIndivid(), openNewIndividModal() |
| `ver9c/3_sd/3_sd_del_concept_individ/3_sd_del_concept_individ_logic.js` | Updated getConceptsManual(), findProcessIndividualsManual(), findConceptAsIndividualInTrigs(), openDelConceptModal(), and other functions |

## Test Plan

- [x] Load index.html from ver9c directory
- [x] Select "Trig_VADv7.ttl" from the example dropdown
- [x] Verify no "currentQuads is not defined" error appears in console
- [x] Verify the diagram is displayed correctly
- [x] Verify Smart Design dropdowns are populated

## Issue Reference

Fixes bpmbpm/rdf-grapher#326

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)