### PR TITLE
Issue #353: Remove Node.js-specific code to fix browser error

### DIFF
--- a/ver9c/9_vadlib/vadlib.js
+++ b/ver9c/9_vadlib/vadlib.js
@@ -1,24 +1,6 @@
 // Ссылка на issue: https://github.com/bpmbpm/rdf-grapher/issues/232
 // vadlib.js - Основная библиотека утилит RDF Grapher
 
-// Import Comunica for full SPARQL support
-// Make it global so it's accessible from other modules
-// Note: This code only runs in Node.js environment; browsers load Comunica via <script> tag
-if (typeof global !== 'undefined' && typeof require === 'function') {
-    global.Comunica = null;
-    try {
-        // Try to import new Comunica package structure
-        global.Comunica = require('@comunica/query-sparql-rdfjs');
-    } catch (error) {
-        try {
-            // Fallback to legacy Comunica package
-            global.Comunica = require('comunica');
-        } catch (legacyError) {
-            console.warn('Comunica SPARQL engine not available - using fallback SPARQL implementation');
-        }
-    }
-}
-
 // ============================================================================
 // РЕЖИМ ВИЗУАЛИЗАЦИИ
 // ============================================================================
@@ -180,13 +162,7 @@ let draggedPanel = null;
 let dragOffsetX = 0;
 let dragOffsetY = 0;
 let currentStore = null;
-// Note: comunicaEngine may be declared in vadlib_sparql.js, so we use var and check
-if (typeof comunicaEngine === 'undefined') {
-    var comunicaEngine = null;
-}
-if (typeof global !== 'undefined') {
-    global.comunicaEngine = comunicaEngine;
-}
+// Note: comunicaEngine is declared in vadlib_sparql.js
 let currentDotCode = '';
 // issue #324: virtualRDFdata удалён - виртуальные данные хранятся в TriG типа vad:Virtual (vt_*)
 let smartDesignMode = 'filtered';


### PR DESCRIPTION
## Summary

Fixes the "Error loading technology application" issue where the file `vad-basic-ontology_tech_Appendix.ttl` appeared to be missing.

### Root Cause

The actual problem was NOT a missing file - the file exists and is accessible. The root cause was a JavaScript runtime error:

```
ReferenceError: global is not defined
    at vadlib.js:6:1
```

This error occurred because `vadlib.js` was using Node.js-specific constructs (`global` and `require()`) that don't exist in browser environments. This caused the entire script to fail during initialization, which cascaded into the tech appendix loading failure.

### Solution

Following the ver9b pattern as requested by the repository owner:
- **Remove** Node.js import block (`global.Comunica`, `require()` calls)
- **Remove** duplicate `comunicaEngine` declaration (already declared in `vadlib_sparql.js`)

The ver9b approach uses pure browser JavaScript without Node.js compatibility code:
- In browser environments, Comunica is loaded via `<script>` tag in HTML, not via `require()`
- The `comunicaEngine` variable is declared in `vadlib_sparql.js` using conditional `var` declaration for browser compatibility

### Testing

Tested locally using Playwright browser automation:
- Before fix: Error dialog "Ошибка загрузки технологического приложения" appeared
- After fix: Application loads successfully with console messages:
  - `Tech appendix loaded successfully`
  - `Predicate groups: 7`
  - `Auto-generated predicates: 5`
  - `Tech quads count: 267`
  - `Window config loaded successfully`
- Example files (Trig_VADv7.ttl) load and render correctly

Fixes #353

---
*Generated with [Claude Code](https://claude.ai/code)*