### PR TITLE
issue #374: Fix Object Card showing 'No properties' for objects in special graphs (rtree)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/374
-Your prepared branch: issue-374-d137a739d78e
-Your prepared working directory: /tmp/gh-issue-solver-1770839398715
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR fixes the issue where selecting objects like `vad:Executor3` in the TreeView showed "Нет свойств для объекта vad:Executor3" (No properties for object) even though these objects have properties defined in `vad:rtree`.

### Root Cause

In `displayObjectProperties()` function in `5_publisher_treeview_ui.js`, the logic only added properties to the display list when `graphUri === contextTrigUri`. However:

1. Objects like `vad:Executor3` are defined in `vad:rtree` (Дерево Исполнителей)
2. When clicking on these objects, `contextTrigUri` was either `null` or a different TriG URI
3. This caused properties from `vad:rtree` to be ignored

### Solution

Added fallback logic to show properties from special graphs (`vad:rtree`) even when they don't match the current selected TriG context. This aligns with the existing behavior in `5_publisher_ui.js` which had similar fallback logic.

### Changes

- `ver9d/5_publisher/5_publisher_treeview/5_publisher_treeview_ui.js`:
  - Added fallback in `displayObjectProperties()` to show properties from `RTREE_GRAPH_URI` 
  - Also shows all properties when no TriG is selected (`!contextTrigUri`)

### Test Plan

- [ ] Load Trig_VADv8.ttl (or similar data with executors)
- [ ] In the TreeView, expand `vad:rtree` tree
- [ ] Click on `vad:Executor3` (or any executor)
- [ ] Verify the Object Card panel shows the executor's properties (`rdf:type`, `rdfs:label`, `vad:hasParentObj`)
- [ ] Verify the fix works both when a TriG is selected and when none is selected

---
Fixes bpmbpm/rdf-grapher#374

🤖 Generated with [Claude Code](https://claude.com/claude-code)