### PR TITLE
fix: issue #439 — move VADProcessDia type check inside GRAPH clause

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/439
-Your prepared branch: issue-439-da4b5f753eff
-Your prepared working directory: /tmp/gh-issue-solver-1772008856194
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/439
+Your prepared branch: issue-439-da4b5f753eff
+Your prepared working directory: /tmp/gh-issue-solver-1772008856194
+Your forked repository: konard/bpmbpm-rdf-grapher
+Original repository (upstream): bpmbpm/rdf-grapher
+
+Proceed.

--- a/ver9d/3_sd/3_sd_del_concept_individ/3_sd_del_concept_individ_sparql.js
+++ b/ver9d/3_sd/3_sd_del_concept_individ/3_sd_del_concept_individ_sparql.js
@@ -125,11 +125,12 @@ SELECT ?child ?label WHERE {
 PREFIX vad: <http://example.org/vad#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
+# issue #439: rdf:type VADProcessDia is stored inside named graphs, not in the default graph
 SELECT DISTINCT ?trig ?processIndivid WHERE {
     GRAPH ?trig {
+        ?trig rdf:type vad:VADProcessDia .
         ?processIndivid vad:includes <${executorUri}> .
     }
-    ?trig rdf:type vad:VADProcessDia .
 }`,
 
     /**
@@ -140,9 +141,12 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX vad: <http://example.org/vad#>
 
+# issue #439: rdf:type VADProcessDia is stored inside named graphs, not in the default graph
 SELECT ?trig ?label WHERE {
-    ?trig rdf:type vad:VADProcessDia .
-    OPTIONAL { ?trig rdfs:label ?label }
+    GRAPH ?trig {
+        ?trig rdf:type vad:VADProcessDia .
+        OPTIONAL { ?trig rdfs:label ?label }
+    }
 }`,
 
     /**
@@ -160,12 +164,11 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX vad: <http://example.org/vad#>
 
 # Issue #221 Fix #2: Ищем использования концепта как индивида во всех TriG типа VADProcessDia
+# issue #439: rdf:type VADProcessDia is stored inside named graphs, not in the default graph
 SELECT ?individ ?trig ?label WHERE {
-    # Находим TriG типа VADProcessDia
-    ?trig rdf:type vad:VADProcessDia .
-
-    # Ищем данный концепт как индивид (подпроцесс) в этих TriG
+    # Находим TriG типа VADProcessDia и ищем концепт как индивид (подпроцесс)
     GRAPH ?trig {
+        ?trig rdf:type vad:VADProcessDia .
         <${conceptUri}> vad:isSubprocessTrig ?trig .
     }
 
@@ -188,11 +191,12 @@ SELECT ?individ ?trig ?label WHERE {
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX vad: <http://example.org/vad#>
 
+# issue #439: rdf:type VADProcessDia is stored inside named graphs, not in the default graph
 SELECT DISTINCT ?trig ?processIndivid WHERE {
     GRAPH ?trig {
+        ?trig rdf:type vad:VADProcessDia .
         ?processIndivid vad:includes <${executorUri}> .
     }
-    ?trig rdf:type vad:VADProcessDia .
 }`,
 
     /**


### PR DESCRIPTION
## Summary

Fixes #439

### Root Cause

In the RDF data (`rdf-data_clip.ttl`), the type declaration `rdf:type vad:VADProcessDia` is stored **inside** named graphs:

```turtle
vad:t_p1 {
    vad:t_p1 a vad:VADProcessDia;   ← declared INSIDE the named graph
    ...
    vad:ExecutorGroup_p1_2 vad:includes vad:Executor2
}
```

The SPARQL queries were checking `?trig rdf:type vad:VADProcessDia` **outside** any `GRAPH` block, which only matches triples in the default graph — resulting in empty results and causing deletion checks to incorrectly report "Checks passed. Concept can be deleted" even when the executor/concept is actively used.

### Fix

Moved `?trig rdf:type vad:VADProcessDia` inside the `GRAPH ?trig { ... }` block in four affected queries in `3_sd_del_concept_individ_sparql.js`:

| Query | Before | After |
|-------|--------|-------|
| `CHECK_EXECUTOR_USAGE` | type check in default graph | type check inside `GRAPH ?trig` |
| `GET_TRIGS_WITH_EXECUTOR` | type check in default graph | type check inside `GRAPH ?trig` |
| `GET_ALL_TRIGS` | type check in default graph | type check inside `GRAPH ?trig` |
| `GET_PROCESS_INDIVIDUALS_FOR_CONCEPT` | type check in default graph | type check inside `GRAPH ?trig` |

### Example

Before fix — query returned 0 rows (executor appears unused):
```sparql
SELECT DISTINCT ?trig ?processIndivid WHERE {
    GRAPH ?trig {
        ?processIndivid vad:includes <http://example.org/vad#Executor2> .
    }
    ?trig rdf:type vad:VADProcessDia .  ← matches only default graph → 0 results
}
```

After fix — query correctly finds Executor2 in `vad:t_p1`:
```sparql
SELECT DISTINCT ?trig ?processIndivid WHERE {
    GRAPH ?trig {
        ?trig rdf:type vad:VADProcessDia .  ← matches inside named graph ✓
        ?processIndivid vad:includes <http://example.org/vad#Executor2> .
    }
}
```

## Changed Files

- `ver9d/3_sd/3_sd_del_concept_individ/3_sd_del_concept_individ_sparql.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)