### PR TITLE
fix: issue #441 — deletion dialog pre-fill and label display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/441
+Your prepared branch: issue-441-b1499449cce0
+Your prepared working directory: /tmp/gh-issue-solver-1772012377064
+Your forked repository: konard/bpmbpm-rdf-grapher
+Original repository (upstream): bpmbpm/rdf-grapher
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/441
-Your prepared branch: issue-441-b1499449cce0
-Your prepared working directory: /tmp/gh-issue-solver-1772012377064
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.

--- a/ver9d/12_method/12_method_logic.js
+++ b/ver9d/12_method/12_method_logic.js
@@ -270,6 +270,7 @@
          * Удаляет все предикаты vad:includes для ExecutorGroup из указанного TriG
          * issue #336: Реализация метода Delete Individ Executor
          * issue #372: Переработан на SPARQL-Driven подход (без JavaScript fallback)
+         * issue #441: Передаём URI исполнителя (концепта), а не ExecutorGroup
          *
          * Алгоритм работы (аналогично deleteIndividProcessFromTrig):
          * 1. Вызывается окно «Удалить индивид исполнителя в схеме» (openDeleteModal)
@@ -281,7 +282,21 @@
          */
         function deleteIndividExecutorFromTrig(executorGroupUri, trigUri) {
             // issue #372: SPARQL-Driven подход — всегда используем модальное окно
-            const prefixedUri = getPrefixedName(executorGroupUri, currentPrefixes);
+            // issue #441: Находим URI исполнителя (концепта из rtree) через vad:includes
+            // Выпадающий список «Выберите индивид для удаления:» содержит URI исполнителей (объектов vad:includes),
+            // а не URI ExecutorGroup, поэтому передаём именно URI исполнителя
+            const includesUri = 'http://example.org/vad#includes';
+            let executorConceptUri = null;
+            if (currentStore) {
+                const includesQuads = currentStore.getQuads(executorGroupUri, includesUri, null, trigUri);
+                if (includesQuads.length > 0) {
+                    executorConceptUri = includesQuads[0].object.value;
+                }
+            }
+
+            const prefixedUri = executorConceptUri
+                ? getPrefixedName(executorConceptUri, currentPrefixes)
+                : getPrefixedName(executorGroupUri, currentPrefixes);
             const prefixedTrigUri = getPrefixedName(trigUri, currentPrefixes);
 
             // Вызываем окно удаления индивида исполнителя в схеме с предустановленными значениями


### PR DESCRIPTION
## Summary

Fixes two bugs in the deletion dialog ("Del Concept\Individ\Schema") when triggered via the "Методы" (Methods) button in "Свойство объекта диаграммы" (Object properties panel):

- **Bug 1:** When deleting an executor individual via the Method button, the "Выберите индивид для удаления:" dropdown was not pre-filled with the current individual.
- **Bug 2:** When deleting a process individual, the "Выберите индивид для удаления:" dropdown showed only the id, not the expected "id (label)" format.

## Root Causes and Fixes

### Bug 1 — Executor individual not pre-filled

**Root cause:** `deleteIndividExecutorFromTrig` in `12_method_logic.js` was passing the `ExecutorGroup` URI to `openDeleteModal`. However, the "Выберите индивид для удаления:" dropdown is populated with executor **concept** URIs (objects of `vad:includes` predicates), not ExecutorGroup URIs. This mismatch caused the pre-selection to fail.

**Fix:** Before calling `openDeleteModal`, look up the executor concept URI via `currentStore.getQuads(executorGroupUri, vad:includes, null, trigUri)` and pass that URI instead of the ExecutorGroup URI.

**File:** `ver9d/12_method/12_method_logic.js`

### Bug 2 — Process individual shows only id, not "id (label)"

**Root cause:** `findProcessIndividualsInTrig` in `3_sd_del_concept_individ_logic.js` used only `getPrefixedName` for the `label` field, which gives just the prefixed ID (e.g., `vad:p1.1`). The `formatDropdownDisplayText` function needs a human-readable label that differs from the id to display the "id (label)" format.

**Fix:** After finding the process individual via `vad:isSubprocessTrig`, also look up `rdfs:label` from `vad:ptree` — the same pattern used in `getIndividsInTrig` in `3_sd_create_new_individ_logic.js` and `getIndividsForHasNextDia` in `12_method_logic.js`.

**File:** `ver9d/3_sd/3_sd_del_concept_individ/3_sd_del_concept_individ_logic.js`

## Test plan

- [ ] Load example data (Trig_VADv5 or Trig_VADv6)
- [ ] Open a process diagram in the Publisher panel
- [ ] Click "Методы" on a process individual node → select "Delete Individ Process"
  - Verify the "Выберите схему процесса для удаления индивида:" and "Выберите индивид для удаления:" fields are pre-filled
  - Verify "Выберите индивид для удаления:" shows "id (label)" format (e.g., `vad:p1.1 (Process 1)`)
- [ ] Click "Методы" on an executor individual (ExecutorGroup) → select "Delete Individ Executor"
  - Verify the "Выберите схему процесса для удаления индивида исполнителя:" and "Выберите индивид для удаления:" fields are pre-filled with the current executor
- [ ] Verify deletion dialog works correctly via "Del Concept\Individ\Schema" button (no regression)

Fixes bpmbpm/rdf-grapher#441

🤖 Generated with [Claude Code](https://claude.com/claude-code)