### PR TITLE
fix: issue #443 — add rdfs:label lookup for id+label display in deletion dialogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/443
+Your prepared branch: issue-443-9f7928b8c067
+Your prepared working directory: /tmp/gh-issue-solver-1772013724092
+Your forked repository: konard/bpmbpm-rdf-grapher
+Original repository (upstream): bpmbpm/rdf-grapher
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/rdf-grapher/issues/443
-Your prepared branch: issue-443-9f7928b8c067
-Your prepared working directory: /tmp/gh-issue-solver-1772013724092
-Your forked repository: konard/bpmbpm-rdf-grapher
-Original repository (upstream): bpmbpm/rdf-grapher
-
-Proceed.


### PR DESCRIPTION
## Summary

Fixes issue #443: the \"Выберите индивид для удаления:\" (\"Select individual for deletion:\") dropdown in the deletion dialog was pre-filling with only the id (e.g. `vad:Executor1`) instead of the expected \"id (label)\" format (e.g. `vad:Executor1 (Исполнитель 1)`).

This is a follow-up to issue #441 (fixed in PR #442), which applied the same fix to `findProcessIndividualsInTrig`. The same pattern was missing in three other functions in `3_sd_del_concept_individ_logic.js`.

## Root Cause

Three functions used only `getPrefixedName()` to build the display label, without looking up `rdfs:label` from the relevant named graph:

| Function | Graph | Operation |
|---|---|---|
| `findProcessIndividualsManual` | `vad:ptree` | Delete process individual in all schemas |
| `findConceptAsIndividualInTrigs` | `vad:ptree` | Validation when deleting concept used as individual |
| `findExecutorIndividualsInTrig` | `vad:rtree` | Delete executor individual in schema |

## Fix

Each function now:
1. Sets `label` to `getPrefixedName(uri)` as the fallback (prefixed id)
2. Searches all quads for `rdfs:label` in the relevant named graph (`ptree` or `rtree`)
3. Overwrites `label` with the human-readable value if found

The result is passed to `formatDropdownDisplayText(uri, label, prefixes)` which produces `"id (label)"` format when label differs from id, matching the display in all other dropdowns in the application.

This follows the exact same pattern as the fix applied to `findProcessIndividualsInTrig` in issue #441 / PR #442.

## Files Changed

- `ver9d/3_sd/3_sd_del_concept_individ/3_sd_del_concept_individ_logic.js`

Fixes bpmbpm/rdf-grapher#443